### PR TITLE
fix: do not use LevelDB transactions in `checkTx`

### DIFF
--- a/lib/abci/BlockExecutionDBTransactions.js
+++ b/lib/abci/BlockExecutionDBTransactions.js
@@ -29,13 +29,13 @@ class BlockExecutionDBTransactions {
   /**
    * Commit all transactions
    *
-   * @return {Promise<[void]>}
+   * @return {Promise<[LevelDBTransaction]>}
    */
   async commit() {
     return Promise.all(
       Object
         .values(this.transactions)
-        .map(transaction => transaction.db.commit()),
+        .map(transaction => transaction.commit()),
     );
   }
 }

--- a/lib/abci/handlers/checkTxHandlerFactory.js
+++ b/lib/abci/handlers/checkTxHandlerFactory.js
@@ -9,10 +9,10 @@ const InvalidStateTransitionError = require('@dashevo/dpp/lib/stateTransition/er
 const InvalidArgumentAbciError = require('../errors/InvalidArgumentAbciError');
 
 /**
- * @param {DashPlatformProtocol} dpp
+ * @param {DashPlatformProtocol} checkTxDpp
  * @return {checkTxHandler}
  */
-function checkTxHandlerFactory(dpp) {
+function checkTxHandlerFactory(checkTxDpp) {
   /**
    * CheckTx ABCI handler
    *
@@ -29,7 +29,7 @@ function checkTxHandlerFactory(dpp) {
     const stateTransitionSerialized = Buffer.from(stateTransitionByteArray);
 
     try {
-      await dpp.stateTransition.createFromSerialized(stateTransitionSerialized);
+      await checkTxDpp.stateTransition.createFromSerialized(stateTransitionSerialized);
     } catch (e) {
       if (e instanceof InvalidStateTransitionError) {
         throw new InvalidArgumentAbciError('State Transition is invalid', { errors: e.getErrors() });

--- a/lib/abci/handlers/deliverTxHandlerFactory.js
+++ b/lib/abci/handlers/deliverTxHandlerFactory.js
@@ -17,7 +17,7 @@ const stateTransitionTypes = require('@dashevo/dpp/lib/stateTransition/stateTran
 const InvalidArgumentAbciError = require('../errors/InvalidArgumentAbciError');
 
 /**
- * @param {DashPlatformProtocol} dpp
+ * @param {DashPlatformProtocol} deliverTxDpp
  * @param {UpdateStatePromiseClient} driveUpdateStateClient
  * @param {BlockchainState} blockchainState
  * @param {IdentityLevelDBRepository} identityRepository
@@ -26,7 +26,7 @@ const InvalidArgumentAbciError = require('../errors/InvalidArgumentAbciError');
  * @return {deliverTxHandler}
  */
 function deliverTxHandlerFactory(
-  dpp,
+  deliverTxDpp,
   driveUpdateStateClient,
   blockchainState,
   identityRepository,
@@ -49,7 +49,7 @@ function deliverTxHandlerFactory(
 
     let stateTransition;
     try {
-      stateTransition = await dpp
+      stateTransition = await deliverTxDpp
         .stateTransition
         .createFromSerialized(stateTransitionSerialized);
     } catch (e) {
@@ -62,7 +62,7 @@ function deliverTxHandlerFactory(
 
     switch (stateTransition.getType()) {
       case stateTransitionTypes.IDENTITY_CREATE: {
-        const result = await dpp.stateTransition.validateData(stateTransition);
+        const result = await deliverTxDpp.stateTransition.validateData(stateTransition);
         if (!result.isValid()) {
           throw new InvalidArgumentAbciError('Invalid Identity Create Transition', { errors: result.getErrors() });
         }
@@ -74,7 +74,10 @@ function deliverTxHandlerFactory(
           identityDBTransaction,
         );
 
-        const identity = dpp.identity.applyStateTransition(stateTransition, currentIdentity);
+        const identity = deliverTxDpp.identity.applyStateTransition(
+          stateTransition,
+          currentIdentity,
+        );
         if (identity) {
           await identityRepository.store(identity, identityDBTransaction);
         }

--- a/lib/createDIContainer.js
+++ b/lib/createDIContainer.js
@@ -21,6 +21,7 @@ const { UpdateStatePromiseClient } = require('@dashevo/drive-grpc');
 const BlockchainStateLevelDBRepository = require('./state/BlockchainStateLevelDBRepository');
 
 const MachineDataProvider = require('./dpp/MachineDataProvider');
+const TransactionalMachineDataProvider = require('./dpp/TransactionalMachineDataProvider');
 
 const wrapInErrorHandlerFactory = require('./abci/errors/wrapInErrorHandlerFactory');
 
@@ -117,8 +118,16 @@ async function createDIContainer(options) {
     )).singleton(),
 
     dataProvider: asClass(MachineDataProvider),
+    transactionalDataProvider: asClass(TransactionalMachineDataProvider),
 
-    dpp: asClass(DashPlatformProtocol).proxy(),
+    deliverTxDpp: asFunction(transactionalDataProvider => (
+      new DashPlatformProtocol({ dataProvider: transactionalDataProvider })
+    )),
+    checkTxDpp: asClass(DashPlatformProtocol)
+      .proxy(),
+    identityDpp: asFunction(() => (
+      new DashPlatformProtocol({ dataProvider: undefined })
+    )).proxy(),
   });
 
   /*
@@ -129,10 +138,6 @@ async function createDIContainer(options) {
       level(identityLevelDBFile, { valueEncoding: 'binary' })
     )).disposer(levelDB => levelDB.close())
       .singleton(),
-
-    identityDpp: asClass(DashPlatformProtocol)
-      .inject(() => ({ dataProvider: undefined }))
-      .proxy(),
 
     identityRepository: asClass(IdentityLevelDBRepository),
   });

--- a/lib/dpp/MachineDataProvider.js
+++ b/lib/dpp/MachineDataProvider.js
@@ -5,13 +5,11 @@ class MachineDataProvider {
    * @param {ClientHttp} driveApiClient
    * @param {LRUCache} contractCache
    * @param {IdentityLevelDBRepository} identityRepository
-   * @param {BlockExecutionDBTransactions} blockExecutionDBTransactions
    */
-  constructor(driveApiClient, contractCache, identityRepository, blockExecutionDBTransactions) {
+  constructor(driveApiClient, contractCache, identityRepository) {
     this.driveApiClient = driveApiClient;
     this.contractCache = contractCache;
     this.identityRepository = identityRepository;
-    this.blockExecutionDBTransactions = blockExecutionDBTransactions;
   }
 
   /**
@@ -54,9 +52,7 @@ class MachineDataProvider {
    * @return {Promise<null|Identity>}
    */
   async fetchIdentity(id) {
-    const identityTransaction = this.blockExecutionDBTransactions.getIdentityTransaction();
-
-    return this.identityRepository.fetch(id, identityTransaction);
+    return this.identityRepository.fetch(id);
   }
 }
 

--- a/lib/dpp/TransactionalMachineDataProvider.js
+++ b/lib/dpp/TransactionalMachineDataProvider.js
@@ -1,0 +1,29 @@
+const MachineDataProvider = require('./MachineDataProvider');
+
+class TransactionalMachineDataProvider extends MachineDataProvider {
+  /**
+   * @param {ClientHttp} driveApiClient
+   * @param {LRUCache} contractCache
+   * @param {IdentityLevelDBRepository} identityRepository
+   * @param {BlockExecutionDBTransactions} blockExecutionDBTransactions
+   */
+  constructor(driveApiClient, contractCache, identityRepository, blockExecutionDBTransactions) {
+    super(driveApiClient, contractCache, identityRepository);
+
+    this.blockExecutionDBTransactions = blockExecutionDBTransactions;
+  }
+
+  /**
+   *  Fetch Identity by id, including unconfirmed ones
+   *
+   * @param {string} id
+   * @return {Promise<null|Identity>}
+   */
+  async fetchIdentity(id) {
+    const identityTransaction = this.blockExecutionDBTransactions.getIdentityTransaction();
+
+    return this.identityRepository.fetch(id, identityTransaction);
+  }
+}
+
+module.exports = TransactionalMachineDataProvider;

--- a/lib/identity/IdentityLevelDBRepository.js
+++ b/lib/identity/IdentityLevelDBRepository.js
@@ -47,7 +47,7 @@ class IdentityLevelDBRepository {
         this.addKeyPrefix(id),
       );
 
-      return this.dpp.identity.createFromSerialized(encodedIdentity);
+      return this.dpp.identity.createFromSerialized(encodedIdentity, { skipValidation: true });
     } catch (e) {
       if (e.type === 'NotFoundError') {
         return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/machine-abci",
-  "version": "0.3.0-dev.3",
+  "version": "0.3.0-dev.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/machine-abci",
-  "version": "0.3.0-dev.2",
+  "version": "0.3.0-dev.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -145,9 +145,9 @@
       }
     },
     "@dashevo/dpp": {
-      "version": "0.10.0-dev.3",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.10.0-dev.3.tgz",
-      "integrity": "sha512-DED93gUP/UguWvW/GCFpPDPDmnkA64THAi+kBMKSZYZI7fazj+nkP6x6wZnfcUy3jmnqVHyZLwHRRLAYDlAfhQ==",
+      "version": "0.10.0-dev.8",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.10.0-dev.8.tgz",
+      "integrity": "sha512-J2nqzHKjshxWqOy5kgifOefKCiebUPe6Jby35KBR+5OoDz/cJl2bXDtF5UBnBv3qYWUTCrftSyZPeFETPzJgfQ==",
       "requires": {
         "@dashevo/dashcore-lib": "0.18.0",
         "ajv": "^6.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/machine-abci",
-  "version": "0.3.0-dev.3",
+  "version": "0.3.0-dev.4",
   "description": "Dash Platform State Machine",
   "engines": {
     "node": ">=8"
@@ -45,7 +45,7 @@
     "sinon-chai": "^3.3.0"
   },
   "dependencies": {
-    "@dashevo/dpp": "dev",
+    "@dashevo/dpp": "0.10.0-dev.8",
     "@dashevo/drive-grpc": "^0.3.0",
     "@dashevo/grpc-common": "^0.2.0",
     "abci": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/machine-abci",
-  "version": "0.3.0-dev.2",
+  "version": "0.3.0-dev.3",
   "description": "Dash Platform State Machine",
   "engines": {
     "node": ">=8"

--- a/test/unit/abci/BlockExecutionDBTransactions.spec.js
+++ b/test/unit/abci/BlockExecutionDBTransactions.spec.js
@@ -5,11 +5,8 @@ describe('BlockExecutionDBTransactions', () => {
   let identityTransactionMock;
 
   beforeEach(function beforeEach() {
-    const commit = this.sinon.stub();
     identityTransactionMock = {
-      db: {
-        commit,
-      },
+      commit: this.sinon.stub(),
     };
 
     blockExecutionDBTransactions = new BlockExecutionDBTransactions();
@@ -38,6 +35,6 @@ describe('BlockExecutionDBTransactions', () => {
 
     await blockExecutionDBTransactions.commit();
 
-    expect(identityTransactionMock.db.commit).to.be.calledOnce();
+    expect(identityTransactionMock.commit).to.be.calledOnce();
   });
 });

--- a/test/unit/dpp/MachineDataProvider.spec.js
+++ b/test/unit/dpp/MachineDataProvider.spec.js
@@ -7,15 +7,12 @@ describe('MachineDataProvider', () => {
   let contractCacheMock;
   let driveApiClientMock;
   let identityRepositoryMock;
-  let blockExecutionDBTransactionsMock;
   let identity;
-  let identityTransaction;
 
   beforeEach(function beforeEach() {
     contractId = '123';
     contract = {};
     identity = 'identity';
-    identityTransaction = 'identityTransaction';
 
     contractCacheMock = {
       set: this.sinon.stub(),
@@ -30,15 +27,10 @@ describe('MachineDataProvider', () => {
       fetch: this.sinon.stub(),
     };
 
-    blockExecutionDBTransactionsMock = {
-      getIdentityTransaction: this.sinon.stub().returns(identityTransaction),
-    };
-
     dataProvider = new MachineDataProvider(
       driveApiClientMock,
       contractCacheMock,
       identityRepositoryMock,
-      blockExecutionDBTransactionsMock,
     );
   });
 
@@ -113,9 +105,8 @@ describe('MachineDataProvider', () => {
       const result = await dataProvider.fetchIdentity(id);
 
       expect(result).to.equal(identity);
-      expect(blockExecutionDBTransactionsMock.getIdentityTransaction).to.be.calledOnce();
 
-      expect(identityRepositoryMock.fetch).to.be.calledOnceWithExactly(id, identityTransaction);
+      expect(identityRepositoryMock.fetch).to.be.calledOnceWithExactly(id);
     });
   });
 });

--- a/test/unit/dpp/TransactionalMachineDataProvider.spec.js
+++ b/test/unit/dpp/TransactionalMachineDataProvider.spec.js
@@ -1,0 +1,54 @@
+const TransactionalMachineDataProvider = require('../../../lib/dpp/TransactionalMachineDataProvider');
+
+describe('TransactionalMachineDataProvider', () => {
+  let dataProvider;
+  let contractCacheMock;
+  let driveApiClientMock;
+  let identityRepositoryMock;
+  let blockExecutionDBTransactionsMock;
+  let identity;
+  let identityTransaction;
+
+  beforeEach(function beforeEach() {
+    identity = 'identity';
+    identityTransaction = 'identityTransaction';
+
+    contractCacheMock = {
+      set: this.sinon.stub(),
+      get: this.sinon.stub(),
+    };
+
+    driveApiClientMock = {
+      request: this.sinon.stub(),
+    };
+
+    identityRepositoryMock = {
+      fetch: this.sinon.stub(),
+    };
+
+    blockExecutionDBTransactionsMock = {
+      getIdentityTransaction: this.sinon.stub().returns(identityTransaction),
+    };
+
+    dataProvider = new TransactionalMachineDataProvider(
+      driveApiClientMock,
+      contractCacheMock,
+      identityRepositoryMock,
+      blockExecutionDBTransactionsMock,
+    );
+  });
+
+  describe('#fetchIdentity', () => {
+    it('should fetch identity from repository', async () => {
+      const id = 'id';
+      identityRepositoryMock.fetch.resolves(identity);
+
+      const result = await dataProvider.fetchIdentity(id);
+
+      expect(result).to.equal(identity);
+      expect(blockExecutionDBTransactionsMock.getIdentityTransaction).to.be.calledOnce();
+
+      expect(identityRepositoryMock.fetch).to.be.calledOnceWithExactly(id, identityTransaction);
+    });
+  });
+});


### PR DESCRIPTION
bugfixes
checkTx now checks transition outside of level db transactions
IdentityLevelDBRepository fetches identities without validation